### PR TITLE
加討論區，詞條按呢好不好、提供講法外觀小改

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,17 +84,17 @@ gunicorn itaigi.wsgi
 ```bash
 python manage.py createsuperuser
 ```
-email和密碼隨意輸入
+email 和密碼隨意輸入，待會需用此帳密登入
 
 #### 登入管理員並且設定FB app
-1. 用瀏覽器進入 /admin
-2. 輸入剛剛的email和密碼
-3. social application
-provider：FB
-id：590065061070994
-key：db4f3fa26d26890e720d17a83ff5a6fe
-最後左下角choose all site
-其他欄位隨便填
+1. 用瀏覽器進入 http://localhost:8000/admin
+2. 輸入剛剛的 email 和密碼登入
+3. 點選 SOCIAL ACCOUNTS 分類下的 Social applications 的 +Add
+  1. provider：FB
+  2. Client id：2055788134646727
+  3. Secret key：880d339384674341c8bf1e62d8c8e0aa
+  4. 左下角 choose all site
+  5. 其他欄位隨便填
 
 ### google sheet匯入資料庫
 參考[Obtain OAuth2 credentials from Google Developers Console](http://gspread.readthedocs.org/en/latest/oauth2.html)

--- a/devServer.js
+++ b/devServer.js
@@ -17,7 +17,8 @@ app.get('*', function (req, res) {
   res.sendFile(path.join(__dirname, 'index.html'));
 });
 
-app.listen(3000, 'localhost', function (err) {
+//app.listen(3000, 'localhost', function (err) {
+app.listen(3000, '0.0.0.0', function (err) {
   if (err) {
     console.log(err);
     return;

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-router": "^2.5.2",
     "react-transmit": "^2.6.3",
     "react-cookie": "^0.4.7",
+    "react-disqus-thread": "^0.4.0",
     "strict-loader": "^1.1.0",
     "style-loader": "^0.13.1",
     "superagent": "^2.0.0",

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ToLam from '../GuanKiann/ToLam/ToLam';
 import FBTest from '../FBTest/FBTest';
+import Disqus from '../Disqus/Disqus';
 
 import './App.css';
 
@@ -39,6 +40,9 @@ class App extends React.Component {
           }
         )}
       <FBTest/>
+      <div className='ui container'>
+        <Disqus pathname={this.props.location.pathname}/>
+      </div>
       <footer className='app footer inverted'>
         <ul className='ui menu container inverted'>
           <li className='item'>

--- a/src/Disqus/Disqus.jsx
+++ b/src/Disqus/Disqus.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Transmit from 'react-transmit';
+import ReactDisqusThread from 'react-disqus-thread';
+
+class Disqus extends React.Component {
+
+  render() {
+    const { pathname } = this.props.location;
+    return (
+      <ReactDisqusThread
+        shortname='itaigi'
+        title={pathname}
+        url={'http://itaigi.tw' + pathname}/>
+    );
+    }
+}
+
+export default Transmit.createContainer(Disqus, {
+  queries: {
+  },
+});

--- a/src/Disqus/Disqus.jsx
+++ b/src/Disqus/Disqus.jsx
@@ -8,16 +8,18 @@ var debug = Debug('itaigi:Disqus');
 class Disqus extends React.Component {
 
   render() {
-    const { pathname } = this.props.location;
+    const { pathname } = this.props;
+    var decode_path = decodeURI(pathname);
     debug('pathname: ' + pathname);
-    debug('decode pathname: ' + decodeURI(pathname));
+    debug('decode pathname: ' + decode_path);
     return (
       <ReactDisqusThread
         shortname='itaigi'
-        title={decodeURI(pathname)}
-        url={'http://itaigi.tw' + decodeURI(pathname)}/>
+        identifier={decode_path}
+        title={decode_path}
+        url={'http://itaigi.tw' + decode_path}/>
     );
-    }
+  }
 }
 
 export default Transmit.createContainer(Disqus, {

--- a/src/Disqus/Disqus.jsx
+++ b/src/Disqus/Disqus.jsx
@@ -1,16 +1,21 @@
 import React from 'react';
 import Transmit from 'react-transmit';
 import ReactDisqusThread from 'react-disqus-thread';
+import Debug from 'debug';
+
+var debug = Debug('itaigi:Disqus');
 
 class Disqus extends React.Component {
 
   render() {
     const { pathname } = this.props.location;
+    debug('pathname: ' + pathname);
+    debug('decode pathname: ' + decodeURI(pathname));
     return (
       <ReactDisqusThread
         shortname='itaigi'
-        title={pathname}
-        url={'http://itaigi.tw' + pathname}/>
+        title={decodeURI(pathname)}
+        url={'http://itaigi.tw' + decodeURI(pathname)}/>
     );
     }
 }

--- a/src/GuanKiann/ABo/ABo.jsx
+++ b/src/GuanKiann/ABo/ABo.jsx
@@ -88,21 +88,22 @@ class ABo extends React.Component {
 
   render有登入鈕仔() {
     return (
-          <button
-            className='ui button'
-            onClick={this.handleSubmit.bind(this)}>送出</button>
+      <button
+        className='ui positive button'
+        onClick={this.handleSubmit.bind(this)}>送出</button>
     );
   }
 
   render無登入鈕仔() {
     return (
-      <div>
-          <button
-            className='ui button'
-            onClick={this.handleSubmit.bind(this)}>匿名送出</button>
+      <div className='ui buttons'>
+        <button
+          className='ui button'
+          onClick={this.handleSubmit.bind(this)}>匿名送出</button>
+        <div className='or'></div>
         <form method='get' action={this.props.後端網址 + 'accounts/facebook/login' }>
-          <input type="submit" className='ui button' value="登入 & 送出"/>
-          <input type="hidden" name="next"
+          <input type='submit' className='ui positive button' value='登入 & 送出'/>
+          <input type='hidden' name='next'
             value={'/%E5%B0%8E%E5%90%91?%E7%B6%B2%E5%9D%80='
               + '//itaigi.tw/k/' + this.props.華語關鍵字
               + '?'
@@ -119,16 +120,24 @@ class ABo extends React.Component {
   render() {
     let { 後端網址 } = this.props;
     return (
-        <div className='ui segment'>
-          <div className='abo ui input'>
-            <input placeholder='漢字' type='text'
-              value={this.state.漢字}
-              onChange={this.handle漢字KeyUp.bind(this)}/>
-          </div>
-          <div className='abo ui input'>
-            <input placeholder='台羅' type='text'
-              value={this.state.音標}
-              onChange={this.handle音標KeyUp.bind(this)}/>
+        <div className='ui form segment'>
+          <div className='fields'>
+            <div className='field'>
+                <label>漢字</label>
+                <div className='abo ui input'>
+                <input placeholder='漢字' type='text'
+                    value={this.state.漢字}
+                    onChange={this.handle漢字KeyUp.bind(this)}/>
+                </div>
+            </div>
+            <div className='field'>
+                <label>台羅</label>
+                <div className='abo ui input'>
+                <input placeholder='台羅' type='text'
+                    value={this.state.音標}
+                    onChange={this.handle音標KeyUp.bind(this)}/>
+                </div>
+            </div>
           </div>
           <LokIm className='abo ui inline'/>
           {this.props.編號 == '無登入' ? this.render無登入鈕仔()

--- a/src/GuanKiann/ABo/ABo.jsx
+++ b/src/GuanKiann/ABo/ABo.jsx
@@ -89,7 +89,7 @@ class ABo extends React.Component {
   render有登入鈕仔() {
     return (
       <button
-        className='ui positive button'
+        className='ui positive button large'
         onClick={this.handleSubmit.bind(this)}>送出</button>
     );
   }
@@ -98,11 +98,11 @@ class ABo extends React.Component {
     return (
       <div className='ui buttons'>
         <button
-          className='ui button'
+          className='ui button large'
           onClick={this.handleSubmit.bind(this)}>匿名送出</button>
         <div className='or'></div>
         <form method='get' action={this.props.後端網址 + 'accounts/facebook/login' }>
-          <input type='submit' className='ui positive button' value='登入 & 送出'/>
+          <input type='submit' className='ui positive button large' value='登入 & 送出'/>
           <input type='hidden' name='next'
             value={'/%E5%B0%8E%E5%90%91?%E7%B6%B2%E5%9D%80='
               + '//itaigi.tw/k/' + this.props.華語關鍵字
@@ -124,7 +124,7 @@ class ABo extends React.Component {
           <div className='fields'>
             <div className='field'>
                 <label>漢字</label>
-                <div className='abo ui input'>
+                <div className='abo ui input large'>
                 <input placeholder='漢字' type='text'
                     value={this.state.漢字}
                     onChange={this.handle漢字KeyUp.bind(this)}/>
@@ -132,7 +132,7 @@ class ABo extends React.Component {
             </div>
             <div className='field'>
                 <label>台羅</label>
-                <div className='abo ui input'>
+                <div className='abo ui input large'>
                 <input placeholder='台羅' type='text'
                     value={this.state.音標}
                     onChange={this.handle音標KeyUp.bind(this)}/>

--- a/src/GuanKiann/GuaGi/GuaGi.jsx
+++ b/src/GuanKiann/GuaGi/GuaGi.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Transmit from 'react-transmit';
 import Su from '../Su/Su';
-import Disqus from '../../Disqus/Disqus';
 import Promise from 'bluebird';
 var superagent = require('superagent-promise')(require('superagent'), Promise);
 import Debug from 'debug';

--- a/src/GuanKiann/GuaGi/GuaGi.jsx
+++ b/src/GuanKiann/GuaGi/GuaGi.jsx
@@ -32,11 +32,10 @@ class GuaGi extends React.Component {
     );
     return (
     <div className='guaGi'>
-      <div className='ui su segment'>
+      <div className='ui su vertical segment'>
         <div className='ui cards'>
           {suList}
         </div>
-        <Disqus location={this.props.location}/>
       </div>
     </div>
     );

--- a/src/GuanKiann/GuaGi/GuaGi.jsx
+++ b/src/GuanKiann/GuaGi/GuaGi.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Transmit from 'react-transmit';
 import Su from '../Su/Su';
+import Disqus from '../../Disqus/Disqus';
 import Promise from 'bluebird';
 var superagent = require('superagent-promise')(require('superagent'), Promise);
 import Debug from 'debug';
@@ -35,6 +36,7 @@ class GuaGi extends React.Component {
         <div className='ui cards'>
           {suList}
         </div>
+        <Disqus location={this.props.location}/>
       </div>
     </div>
     );

--- a/src/GuanKiann/KiuKongHuat/KiuKongHuat.jsx
+++ b/src/GuanKiann/KiuKongHuat/KiuKongHuat.jsx
@@ -26,7 +26,8 @@ class KiuKongHuat extends React.Component {
     return (
       <div className='ui segment'>
         <h3>{this.props.華語關鍵字 || '找什麼？'}</h3>
-        <button className='ui button' onClick={this.問外語.bind(this)}>
+        <button className='ui button large olive' onClick={this.問外語.bind(this)}>
+          <i className='student icon'></i>
           求講法
         </button>
       </div>

--- a/src/GuanKiann/LokIm/LokIm.jsx
+++ b/src/GuanKiann/LokIm/LokIm.jsx
@@ -68,7 +68,7 @@ class LokIm extends React.Component {
 
   renderPlay() {
     if (this.state && this.state.recording) {
-      return <button className='ui icon button' onClick={this.handlePlayClick.bind(this)}>
+      return <button className='ui icon button large' onClick={this.handlePlayClick.bind(this)}>
         <i className='play icon'/>
       </button>;
     } else
@@ -78,10 +78,10 @@ class LokIm extends React.Component {
   render() {
     return (
       <div className='ui input'>
-      <button className='ui icon button' onClick={this.handleMicClick.bind(this)}>
+      <button className='ui icon button large' onClick={this.handleMicClick.bind(this)}>
         <i className='ui unmute icon'/>
       </button>
-      <button className='ui icon button' onClick={this.handleStopClick.bind(this)}>
+      <button className='ui icon button large' onClick={this.handleStopClick.bind(this)}>
          <i className='ui stop icon'/>
       </button>
       <audio ref={(r) => this.audioElement = r} src='' />

--- a/src/GuanKiann/LokIm/LokIm.jsx
+++ b/src/GuanKiann/LokIm/LokIm.jsx
@@ -72,7 +72,7 @@ class LokIm extends React.Component {
         <i className='play icon'/>
       </button>;
     } else
-      return <div> rien </div>;
+      return <div></div>;
   }
 
   render() {

--- a/src/GuanKiann/Su/Su.jsx
+++ b/src/GuanKiann/Su/Su.jsx
@@ -83,47 +83,30 @@ class Su extends React.Component {
         <HuatIm suData={suData} />
         <div className='description'>
             <LaiLik laiLikId={suData.來源} 後端網址={後端網址} />
-            對應華語詞：
+            華語：
             <span className='ui horizontal list'>
               {按呢講的外語}
             </span>
         </div>
-        <div className='ui list'>
-          <div className='item'>
-            <i className='thumbs outline up icon'></i>
-            <div className='content'>
-              按呢講好 <span className='ui yellow circular label'>{this.state.按呢講好 || suData.按呢講好}</span>
-              <div
-                className={
-                  'ui button left pointing label green'
-                  + (this.state.voted ? ' disabled' : '')
-                }
-                onClick={this.投票.bind(this, '按呢講好')}>
-              +1
-              </div>
-            </div>
-          </div>
-          <div className='item'>
-            <i className='thumbs outline down icon'></i>
-            <div className='content'>
-              按呢怪怪 <span className='ui orange circular label'>{this.state.按呢無好 || suData.按呢無好}</span>
-              <div
-                className={
-                  'ui button left pointing label teal'
-                  + (this.state.voted ? ' disabled' : '')
-                }
-                onClick={this.投票.bind(this, '按呢無好')}>
-              +1
-              </div>
-            </div>
-          </div>
+        <br/>
+        <div className='ui compact menu'>
+          <a className={
+              'item'
+              + (this.state.voted ? ' disabled' : '')}
+          onClick={this.投票.bind(this, '按呢講好')}>
+          <i className='icon heart'></i>
+          按呢講好 <span className='floating ui label yellow'>{this.state.按呢講好 || suData.按呢講好}</span>
+          </a>
+          <a className={
+              'item'
+              + (this.state.voted ? ' disabled' : '')}
+          onClick={this.投票.bind(this, '按呢無好')}>
+          <i className='icon help circle'></i>
+          按呢怪怪 <span className='floating ui label orange'>{this.state.按呢無好 || suData.按呢無好}</span>
+          </a>
         </div>
       </div>
       <div className='extra content'>
-        <span className='left floated'>
-          <i className='comments outline icon'></i>
-          討論 (6)
-        </span>
         <a className='right floated plus'>
           <i className='plus icon'></i>
           加入討論

--- a/src/GuanKiann/Su/Su.jsx
+++ b/src/GuanKiann/Su/Su.jsx
@@ -73,44 +73,38 @@ class Su extends React.Component {
     <div className='su card'>
       <div className='content'>
         <div className='left floated'>
-          <h3 className='header green'>
+          <h2 className='ui header'>
           {suText}
-          </h3>
+          </h2>
           <div className='meta'>
             {suIm}
           </div>
         </div>
         <HuatIm suData={suData} />
         <div className='description'>
-            <LaiLik laiLikId={suData.來源} 後端網址={後端網址} />
-            華語：
-            <span className='ui horizontal list'>
-              {按呢講的外語}
-            </span>
+          <LaiLik laiLikId={suData.來源} 後端網址={後端網址} />
+          華語：
+          <span className='ui horizontal list large'>
+            {按呢講的外語}
+          </span>
         </div>
         <br/>
-        <div className='ui compact menu'>
+        <div className='ui compact menu large'>
           <a className={
-              'item'
-              + (this.state.voted ? ' disabled' : '')}
-          onClick={this.投票.bind(this, '按呢講好')}>
-          <i className='icon heart'></i>
-          按呢講好 <span className='floating ui label yellow'>{this.state.按呢講好 || suData.按呢講好}</span>
+            'item'
+            + (this.state.voted ? ' disabled' : '')}
+            onClick={this.投票.bind(this, '按呢講好')}>
+            <i className='icon heart'></i>
+            按呢講好 <span className='floating ui label yellow'>{this.state.按呢講好 || suData.按呢講好}</span>
           </a>
           <a className={
-              'item'
-              + (this.state.voted ? ' disabled' : '')}
-          onClick={this.投票.bind(this, '按呢無好')}>
-          <i className='icon help circle'></i>
-          按呢怪怪 <span className='floating ui label orange'>{this.state.按呢無好 || suData.按呢無好}</span>
+            'item'
+            + (this.state.voted ? ' disabled' : '')}
+            onClick={this.投票.bind(this, '按呢無好')}>
+            <i className='icon help circle'></i>
+            按呢怪怪 <span className='floating ui label orange'>{this.state.按呢無好 || suData.按呢無好}</span>
           </a>
         </div>
-      </div>
-      <div className='extra content'>
-        <a className='right floated plus'>
-          <i className='plus icon'></i>
-          加入討論
-        </a>
       </div>
     </div>
     );

--- a/src/GuanKiann/Su/Su.jsx
+++ b/src/GuanKiann/Su/Su.jsx
@@ -73,9 +73,9 @@ class Su extends React.Component {
     <div className='su card'>
       <div className='content'>
         <div className='left floated'>
-          <div className='header green'>
+          <h3 className='header green'>
           {suText}
-          </div>
+          </h3>
           <div className='meta'>
             {suIm}
           </div>
@@ -83,13 +83,16 @@ class Su extends React.Component {
         <HuatIm suData={suData} />
         <div className='description'>
             <LaiLik laiLikId={suData.來源} 後端網址={後端網址} />
-            對應華語詞：{按呢講的外語}
+            對應華語詞：
+            <span className='ui horizontal list'>
+              {按呢講的外語}
+            </span>
         </div>
         <div className='ui list'>
           <div className='item'>
             <i className='thumbs outline up icon'></i>
             <div className='content'>
-              按呢講好<span className='ui yellow circular label'>{this.state.按呢講好 || suData.按呢講好}</span>
+              按呢講好 <span className='ui yellow circular label'>{this.state.按呢講好 || suData.按呢講好}</span>
               <div
                 className={
                   'ui button left pointing label green'
@@ -103,7 +106,7 @@ class Su extends React.Component {
           <div className='item'>
             <i className='thumbs outline down icon'></i>
             <div className='content'>
-              按呢怪怪<span className='ui orange circular label'>{this.state.按呢無好 || suData.按呢無好}</span>
+              按呢怪怪 <span className='ui orange circular label'>{this.state.按呢無好 || suData.按呢無好}</span>
               <div
                 className={
                   'ui button left pointing label teal'
@@ -114,13 +117,17 @@ class Su extends React.Component {
               </div>
             </div>
           </div>
-          <div className='item'>
-            <i className='comments outline icon'></i>
-            <div className='content'>
-              討論 (6)
-            </div>
-          </div>
         </div>
+      </div>
+      <div className='extra content'>
+        <span className='left floated'>
+          <i className='comments outline icon'></i>
+          討論 (6)
+        </span>
+        <a className='right floated plus'>
+          <i className='plus icon'></i>
+          加入討論
+        </a>
       </div>
     </div>
     );

--- a/src/GuanKiann/Su/TuiIngHuaGi.js
+++ b/src/GuanKiann/Su/TuiIngHuaGi.js
@@ -11,7 +11,7 @@ class TuiIngHuaGi extends React.Component {
   render() {
     const { 外語 } = this.props;
     return (
-    <span key={外語.外語項目編號}> {外語.外語資料} </span>
+    <a className='item' href={'/k/' + 外語.外語資料} key={外語.外語項目編號}> {外語.外語資料} </a>
     );
   }
 }

--- a/src/GuanKiann/Tshue/Tshue.jsx
+++ b/src/GuanKiann/Tshue/Tshue.jsx
@@ -39,7 +39,11 @@ class Tshue extends React.Component {
         onKeyDown={this.handleKeyDown.bind(this)}
         onKeyUp={this.handleKeyUp.bind(this)}
       />
-      <div className="ui button big teal" onClick={this.handleSubmit.bind(this)}>台語怎麼講</div>
+      <div className='ui button big teal'
+        onClick={this.handleSubmit.bind(this)}>
+        <i className='translate icon'></i>
+        台語怎麼講
+      </div>
     </div>
     );
   }

--- a/src/Iah/Kong/Kong.jsx
+++ b/src/Iah/Kong/Kong.jsx
@@ -5,6 +5,7 @@ import Tshue from '../../GuanKiann/Tshue/Tshue';
 import ABo from '../../GuanKiann/ABo/ABo';
 import KiuKongHuat from '../../GuanKiann/KiuKongHuat/KiuKongHuat';
 import GuaGi from '../../GuanKiann/GuaGi/GuaGi';
+import Disqus from '../../Disqus/Disqus';
 import Promise from 'bluebird';
 var superagent = require('superagent-promise')(require('superagent'), Promise);
 import Debug from 'debug';
@@ -70,7 +71,6 @@ class Kong extends React.Component {
       <GuaGi id={g.外語項目編號}
         key={g.外語項目編號} 新詞文本={g.新詞文本}
         csrftoken={this.props.csrftoken}
-        location={this.props.location}
         後端網址={this.props.後端網址}/>
     ))}
       <h3>啊無咧？</h3>
@@ -78,6 +78,7 @@ class Kong extends React.Component {
        後端網址={this.props.後端網址} csrftoken={this.props.csrftoken}
        編號={this.props.編號} 漢字={this.props.location.query.漢字} 音標={this.props.location.query.音標}
        />
+      <Disqus location={this.props.location}/>
     </div>
     );
   }

--- a/src/Iah/Kong/Kong.jsx
+++ b/src/Iah/Kong/Kong.jsx
@@ -36,11 +36,12 @@ class Kong extends React.Component {
       <div className='ui segment'>
         <h3>找「{this.props.kongData.關鍵字}」錯了嗎？</h3>
         {this.props.kongData.內容}
-        <button className='ui button'>
+        <button className='ui button large olive'>
+          <i className='student icon'></i>
           求講法
         </button>
       </div>
-      <h3>我就是沒有人，我來講</h3>
+      <h3>我會曉，會使按呢講</h3>
       <ABo 華語關鍵字={this.props.kongData.關鍵字}
         後端網址={this.props.後端網址} csrftoken={this.props.csrftoken}
         編號={this.props.編號} 漢字={this.props.location.query.漢字} 音標={this.props.location.query.音標}
@@ -56,11 +57,20 @@ class Kong extends React.Component {
       <div className='tshueBo'>
         <KiuKongHuat 華語關鍵字={this.props.kongData.關鍵字}
           後端網址={this.props.後端網址} csrftoken={this.props.csrftoken} />
-        <h3>我就是沒有人，我來講</h3>
+        <h3 className='ui horizontal divider header'>
+          <i className='cloud upload icon'></i>
+          我會曉，會使按呢講
+        </h3>
         <ABo 華語關鍵字={this.props.kongData.關鍵字}
           後端網址={this.props.後端網址} csrftoken={this.props.csrftoken}
           編號={this.props.編號} 漢字={this.props.location.query.漢字} 音標={this.props.location.query.音標}
         />
+        <h3 className='ui horizontal divider header'>
+          <i className='outline comments icon'></i>
+          來討論
+          <span className='ui pink header'> {this.props.kongData.關鍵字}</span>
+        </h3>
+        <Disqus pathname={this.props.location.pathname}/>
       </div>
       );
     }
@@ -68,31 +78,43 @@ class Kong extends React.Component {
     return (
     <div className='kongHuat'>
       {this.props.kongData.內容.列表.map((g) => (
-      <GuaGi id={g.外語項目編號}
-        key={g.外語項目編號} 新詞文本={g.新詞文本}
-        csrftoken={this.props.csrftoken}
-        後端網址={this.props.後端網址}/>
-    ))}
-      <h3>啊無咧？</h3>
+        <GuaGi id={g.外語項目編號}
+          key={g.外語項目編號} 新詞文本={g.新詞文本}
+          csrftoken={this.props.csrftoken}
+          後端網址={this.props.後端網址}/>
+      ))}
+      <h3 className='ui horizontal divider header'>
+        <i className='cloud upload icon'></i>
+        閣會使按呢講，我來做伙添
+      </h3>
       <ABo 華語關鍵字={this.props.kongData.關鍵字}
        後端網址={this.props.後端網址} csrftoken={this.props.csrftoken}
        編號={this.props.編號} 漢字={this.props.location.query.漢字} 音標={this.props.location.query.音標}
        />
-      <Disqus location={this.props.location}/>
+      <h3 className='ui horizontal divider header'>
+        <i className='outline comments icon'></i>
+        來討論
+        <span className='ui pink header'> {this.props.kongData.關鍵字}</span>
+      </h3>
+      <Disqus pathname={this.props.location.pathname}/>
     </div>
     );
   }
 
   renderKianGi() {
     return (
-        <div className='kianGi'>
-        {this.props.kongData.內容.其他建議.map((g) =>
-            <GuaGi id={g.外語項目編號}
-              key={g.外語項目編號} 新詞文本={g.新詞文本}
-              後端網址={this.props.後端網址}/>
-            )}
-        </div>
-        );
+    <div className='kianGi'>
+      <h3 className='ui horizontal divider header'>
+        <i className='book icon'></i>
+        相關的詞
+      </h3>
+      {this.props.kongData.內容.其他建議.map((g) =>
+        <GuaGi id={g.外語項目編號}
+          key={g.外語項目編號} 新詞文本={g.新詞文本}
+          後端網址={this.props.後端網址}/>
+      )}
+    </div>
+    );
   }
 
   render() {
@@ -107,9 +129,9 @@ class Kong extends React.Component {
       </nav>
       <div className='kong content'>
         {this.props.kongData.結果 >= 0 ? this.renderKiatKo()
-      : this.props.kongData.結果 === -1 ? this.renderTshoGoo()
+        : this.props.kongData.結果 === -1 ? this.renderTshoGoo()
         : this.renderTshueSiann()}
-        {this.props.kongData.結果 >= 0 ? this.renderKianGi() : []}
+        {this.props.kongData.結果 > 0 ? this.renderKianGi() : []}
       </div>
     </div>
     );

--- a/src/Iah/Kong/Kong.jsx
+++ b/src/Iah/Kong/Kong.jsx
@@ -68,7 +68,7 @@ class Kong extends React.Component {
         <h3 className='ui horizontal divider header'>
           <i className='outline comments icon'></i>
           來討論
-          <span className='ui pink header'> {this.props.kongData.關鍵字}</span>
+          「<span className='ui pink header'>{this.props.kongData.關鍵字}</span>」
         </h3>
         <Disqus pathname={this.props.location.pathname}/>
       </div>
@@ -94,7 +94,7 @@ class Kong extends React.Component {
       <h3 className='ui horizontal divider header'>
         <i className='outline comments icon'></i>
         來討論
-        <span className='ui pink header'> {this.props.kongData.關鍵字}</span>
+        「<span className='ui pink header'>{this.props.kongData.關鍵字}</span>」
       </h3>
       <Disqus pathname={this.props.location.pathname}/>
     </div>

--- a/src/Iah/Kong/Kong.jsx
+++ b/src/Iah/Kong/Kong.jsx
@@ -70,6 +70,7 @@ class Kong extends React.Component {
       <GuaGi id={g.外語項目編號}
         key={g.外語項目編號} 新詞文本={g.新詞文本}
         csrftoken={this.props.csrftoken}
+        location={this.props.location}
         後端網址={this.props.後端網址}/>
     ))}
       <h3>啊無咧？</h3>

--- a/src/Iah/The/The.jsx
+++ b/src/Iah/The/The.jsx
@@ -20,24 +20,27 @@ class The extends React.Component {
   {
     let 無建議的外語列表 = this.props.外語列表.列表.map(
       (guaGi)=>(
-        <div key={guaGi.外語項目編號}>
-            <button onClick={this.props.欲提供講法.bind(this, guaGi.外語資料)}>{guaGi.外語資料}</button>
-          </div>
-        )
-      );
+        <button key={guaGi.外語項目編號}
+          className='ui button basic primary large'
+          onClick={this.props.欲提供講法.bind(this, guaGi.外語資料)}>
+          {guaGi.外語資料}
+        </button>
+    )
+    );
     return (
     <div className='main container'>
-        <div className='the content'>
-          <div className='ui forum segment'>
-            <h3>這些詞還沒有人會用台語講</h3>
-            <div>
-              {無建議的外語列表}
-            </div>
-            <h3>我就是沒有人，我來講</h3>
-            <ABo 後端網址={this.props.後端網址} />
+      <div className='the content'>
+        <div className='ui forum segment'>
+          <h3>
+            <i className='spinner icon'></i>
+            這些詞還沒有人會用台語講
+          </h3>
+          <div>
+            {無建議的外語列表}
           </div>
         </div>
       </div>
+    </div>
     );
   }
 
@@ -47,7 +50,10 @@ class The extends React.Component {
       <div className='main container'>
         <div className='the content'>
           <div className='ui forum segment'>
-            <h3>我就是沒有人，我知道「{this.props.params.k}」的講法</h3>
+            <h3 className='ui header'>
+              <i className='cloud upload icon'></i>
+              我會曉，「{this.props.params.k}」會使按呢講
+            </h3>
             <ABo 華語關鍵字={this.props.params.k}
               後端網址={this.props.後端網址} csrftoken={this.props.csrftoken}
               編號={this.props.編號} 漢字={this.props.location.query.漢字} 音標={this.props.location.query.音標}


### PR DESCRIPTION
https://github.com/g0v/itaigi/issues/11
https://github.com/g0v/itaigi/issues/81

按呢講好、按呢怪怪有人跟我反應票數會覺得可以按，所以改了一下設計

使用 disqus 做討論區，短時間要做出像他一樣功能的可能有點困難，自己做的話後端要大改（用[channels](https://github.com/andrewgodwin/channels) 以 websocket 來做即時聊天功能）
disqus 有個我覺得很好的地方是可以設定有人留言要不要收到 email 通知
目前只做完華語詞底下的留言區，可以先用用看，台語詞條個別討論區目前是想說按了 _加入討論_ 後再跳轉過去，但頁面要想一下，是不是還有其他資料可以一起顯示

外觀
![image](https://cloud.githubusercontent.com/assets/4479861/16773702/721af472-488b-11e6-98cf-431dd06aad73.png)
![image](https://cloud.githubusercontent.com/assets/4479861/16773714/7be72840-488b-11e6-9b33-fbe99c8da03a.png)
