### PR TITLE
指定Modal z-index, 才不會被數字擋到

### DIFF
--- a/src/GuanKiann/ABo/APui.jsx
+++ b/src/GuanKiann/ABo/APui.jsx
@@ -3,6 +3,9 @@ import Transmit from 'react-transmit';
 import Modal from 'react-modal';
 
 const customStyles = {
+  overlay: {
+    zIndex: '200',
+  },
   content: {
     top: '50%',
     left: '50%',


### PR DESCRIPTION
#230 

Semantic UI floating item 設定 z-index: 100
Modal 的 overlay z-index要更大才不會被擋到