### PR TITLE
直接用punycode

### DIFF
--- a/src/後端.jsx
+++ b/src/後端.jsx
@@ -10,7 +10,8 @@ export default class 後端  {
   }
 
   static 例句列表(漢字, 臺羅) {
-    return encodeURI('https://例句.意傳.台灣/' + '看/?漢字=' + 漢字 + '&臺羅=' + 臺羅);
+    'safari需要直接用punycode';
+    return encodeURI('https://xn--fsqx9h.xn--v0qr21b.xn--kpry57d/' + '看/?漢字=' + 漢字 + '&臺羅=' + 臺羅);
   }
 
   static 貢獻者表() {


### PR DESCRIPTION
因為safari的encodeURI會共
https://例句.意傳.台灣/看/?漢字=老爸&臺羅=lāu-pē
轉做
https://%e4%be%8b%e5%8f%a5.%e6%84%8f%e5%82%b3.%e5%8f%b0%e7%81%a3/%E7%9C%8B/?%E6%BC%A2%E5%AD%97=%E8%80%81%E7%88%B8&%E8%87%BA%E7%BE%85=l%C4%81u-p%C4%93