### PR TITLE
關閉搜尋列的定時搜尋

### DIFF
--- a/src/GuanKiann/Tshue/Tshue.jsx
+++ b/src/GuanKiann/Tshue/Tshue.jsx
@@ -43,14 +43,6 @@ export default class Tshue extends React.Component {
     }
   }
 
-  componentWillMount() {
-    this.timer = setInterval(this.查怎樣講.bind(this), 2000);
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.timer);
-  }
-
   render() {
     return (
     <div className='ui fluid action input huge container tshue'>


### PR DESCRIPTION
自動定時搜尋會先送出部份文字的ajax，
在最終搜尋的文字ajax還沒回來之前就顯示舊的ajax。

暫定取消自動定時搜尋。
```
ellen [11:05 PM] 
單字的發音 不見了
句子的還在
之前有遇過  第一次搜尋的字發音 會蓋掉第二次搜尋的字 發音 的問題

sing5hong5 [11:27 PM] 
let's好矣
@liz 修好矣
@johnny let's 愛先指過來才有法度簽
來睏~~
@ellen 按呢，阮共自動搜尋的功能關掉？
```
![2017-10-29 14-21-07](https://user-images.githubusercontent.com/6355592/32141187-a28e6816-bcb4-11e7-860f-77467f4d2c76.png)
