### PR TITLE
Card design

### DIFF
--- a/src/App/App.css
+++ b/src/App/App.css
@@ -46,7 +46,7 @@ body {
 }
 
 /* Mobile */
-@media only screen and (max-width: 767px) {
+@media only screen and (max-width: 727px) {
   .app .main.container {
     width: auto !important;
     margin-left: 1em !important;
@@ -71,16 +71,15 @@ body {
 }
 
 .ui.header{
-  font-size: 24px;
+  font-size: 28px !important;
   font-family: "MOEDICT", "FiraSansOT-Regular", sans-serif;
-  padding-top: 1em;
-  padding-right: 0.66em;
-  padding-left: 0.66em;
+  padding-top: 0.5em;
+  padding-left: 0.33em;
 }
 
 div.description{
   font-family: "FiraSansOT-Regular", sans-serif;
-  padding-top: 0.5em;
+  font-size: 17.5px;
   padding-right: 0.66em;
   padding-left: 0.66em;
 }
@@ -88,27 +87,25 @@ div.description{
 div.subtext{
   font-size: 14px;
   font-family: "FiraSansOT-Regular", sans-serif;
-  padding-top: 0.66em;
-  padding-bottom: 0.66em;
+  padding-top: 1em;
+  padding-bottom: 3em;
   padding-right: 0.66em;
   padding-left: 0.66em;
 }
+
 div.actions{
-  font-size: 16px;
-  font-family: "FiraSansOT-Regular", sans-serif;
-  padding-top: 0.33em;
-  padding-bottom: 0.33em;
-  padding-right: 0.33em;
-  padding-left: 0.33em;
-}
-div.actions a{
-  margin: .33em;
+  position: absolute;
+  margin: 0.33em;
+  right: 1.33em;
+  bottom: 1.33em;
+  text-decoration: none;
+  display: inline-block;
 }
 
 .disabled{
   color: #999999;
 }
 
-a {
-  color: #333333;
+.content{
+  position: relative;
 }

--- a/src/App/App.css
+++ b/src/App/App.css
@@ -70,10 +70,45 @@ body {
   src: url(https://www.moedict.tw/fonts/FiraSansOT-Regular.woff);
 }
 
-h2.ui.header{
-	font-family: "MOEDICT", "FiraSansOT-Regular", sans-serif;
+.ui.header{
+  font-size: 24px;
+  font-family: "MOEDICT", "FiraSansOT-Regular", sans-serif;
+  padding-top: 1em;
+  padding-right: 0.66em;
+  padding-left: 0.66em;
 }
 
 div.description{
-  font-family: "FiraSansOT-Regular", sans-serif;  
+  font-family: "FiraSansOT-Regular", sans-serif;
+  padding-top: 0.5em;
+  padding-right: 0.66em;
+  padding-left: 0.66em;
+}
+
+div.subtext{
+  font-size: 14px;
+  font-family: "FiraSansOT-Regular", sans-serif;
+  padding-top: 0.66em;
+  padding-bottom: 0.66em;
+  padding-right: 0.66em;
+  padding-left: 0.66em;
+}
+div.actions{
+  font-size: 16px;
+  font-family: "FiraSansOT-Regular", sans-serif;
+  padding-top: 0.33em;
+  padding-bottom: 0.33em;
+  padding-right: 0.33em;
+  padding-left: 0.33em;
+}
+div.actions a{
+  margin: .33em;
+}
+
+.disabled{
+  color: #999999;
+}
+
+a {
+  color: #333333;
 }

--- a/src/FBTest/FBTest.jsx
+++ b/src/FBTest/FBTest.jsx
@@ -51,7 +51,7 @@ export default class FBTest extends React.Component {
       <div className='ui middle aligned stackable grid container'>
         <div className='row'>
           <div className='eight wide column'>
-            <h1 className='ui header'>快分享 iTaigi 給你的朋友知道吧！</h1>
+            <div className='ui header'>快分享 iTaigi 給你的朋友知道吧！</div>
             <分享鍵 size='large' pathname={ '' }/>
           </div>
 

--- a/src/GuanKiann/GuaGi/GuaGi.css
+++ b/src/GuanKiann/GuaGi/GuaGi.css
@@ -4,3 +4,9 @@
     justify-content: center;
   }
 }
+
+@media only screen and (min-width: 767px) {
+  .ui.su.card{
+    width: 310px;
+  }
+}

--- a/src/GuanKiann/GuaGi/GuaGi.css
+++ b/src/GuanKiann/GuaGi/GuaGi.css
@@ -1,12 +1,13 @@
 /* Mobile */
-@media only screen and (max-width: 767px) {
-  .guaGi .ui.cards {
+@media only screen and (max-width: 727px) {
+  .ui.su.card{
     justify-content: center;
   }
 }
 
-@media only screen and (min-width: 767px) {
+@media only screen and (min-width: 627px) {
   .ui.su.card{
-    width: 310px;
+    justify-content: center;
+    width: 304px;
   }
 }

--- a/src/GuanKiann/GuaGi/GuaGi.jsx
+++ b/src/GuanKiann/GuaGi/GuaGi.jsx
@@ -57,10 +57,10 @@ export default class GuaGi extends React.Component {
           {suList}
           <div className='ui su card'>
             <div className='content'>
-              <h3 className='ui header'>
+              <div className='ui header'>
                 <i className='cloud upload icon'></i>
                 閣會使按呢講
-              </h3>
+              </div>
               <ABo 華語關鍵字={this.props.華語關鍵字}
                csrftoken={this.props.csrftoken}
                編號={this.props.編號} 漢字={this.props.漢字} 音標={this.props.音標}

--- a/src/GuanKiann/HuatIm/HapSing.jsx
+++ b/src/GuanKiann/HuatIm/HapSing.jsx
@@ -37,10 +37,10 @@ export default class HapSing extends React.Component {
             }
            />
         </audio>
-        <a onClick={this.play.bind(this)}
+        <span className='ui icon button' onClick={this.play.bind(this)}
           title='發音' >
           <i className='icon play'></i>
-        </a>
+        </span>
       </span>
     );
   }

--- a/src/GuanKiann/HuatIm/HapSing.jsx
+++ b/src/GuanKiann/HuatIm/HapSing.jsx
@@ -37,12 +37,11 @@ export default class HapSing extends React.Component {
             }
            />
         </audio>
-        <button onClick={this.play.bind(this)}
-          className='ui compact icon button'>
+        <a onClick={this.play.bind(this)}
+          title='發音' >
           <i className='icon play'></i>
-        </button>
+        </a>
       </span>
     );
   }
 };
-

--- a/src/GuanKiann/HuatIm/HuatIm.css
+++ b/src/GuanKiann/HuatIm/HuatIm.css
@@ -1,3 +1,3 @@
-.HuatIm .button {
+/*.HuatIm .button {
     margin-left: 15px;
-}
+}*/

--- a/src/GuanKiann/HuatIm/HuatIm.jsx
+++ b/src/GuanKiann/HuatIm/HuatIm.jsx
@@ -30,10 +30,10 @@ export default class HuatIm extends React.Component {
           src={'https://1763c5ee9859e0316ed6-db85b55a6a3fbe33f09b9245992383bd.ssl.cf1.rackcdn.com/'
           + id + '.mp3'} />
       </audio>
-      <a onClick={this.play.bind(this, 'audio_' + id)}
+      <div className='ui icon button' onClick={this.play.bind(this, 'audio_' + id)}
         title='發音'>
         <i className='icon play'></i>
-      </a>
+      </div>
     </span>
     );
   }

--- a/src/GuanKiann/HuatIm/HuatIm.jsx
+++ b/src/GuanKiann/HuatIm/HuatIm.jsx
@@ -30,10 +30,10 @@ export default class HuatIm extends React.Component {
           src={'https://1763c5ee9859e0316ed6-db85b55a6a3fbe33f09b9245992383bd.ssl.cf1.rackcdn.com/'
           + id + '.mp3'} />
       </audio>
-      <button onClick={this.play.bind(this, 'audio_' + id)}
-        className='ui compact icon button'>
+      <a onClick={this.play.bind(this, 'audio_' + id)}
+        title='發音'>
         <i className='icon play'></i>
-      </button>
+      </a>
     </span>
     );
   }

--- a/src/GuanKiann/LaiLik/LaiLik.jsx
+++ b/src/GuanKiann/LaiLik/LaiLik.jsx
@@ -7,8 +7,7 @@ export default class LaiLik extends React.Component {
   render() {
     return (
     <div className='content'>
-      出處：
-      {this.props.貢獻者}
+      出處： {this.props.貢獻者}
     </div>
     );
   }

--- a/src/GuanKiann/LokIm/LokIm.jsx
+++ b/src/GuanKiann/LokIm/LokIm.jsx
@@ -64,9 +64,9 @@ export default class LokIm extends React.Component {
 
   renderPlay() {
     if (this.state && this.state.recording) {
-      return <button className='ui icon button large' onClick={this.handlePlayClick.bind(this)}>
-        <i className='play icon'/>
-      </button>;
+      return <div className='ui icon button large' onClick={this.handlePlayClick.bind(this)}>
+        <i className='icon play'/>
+      </div>;
     } else
       return <div></div>;
   }

--- a/src/GuanKiann/Su/Su.css
+++ b/src/GuanKiann/Su/Su.css
@@ -2,6 +2,6 @@
   text-align: left;
 }
 
-.report {
+/*.report {
   padding-top: 15px
-}
+}*/

--- a/src/GuanKiann/Su/Su.css
+++ b/src/GuanKiann/Su/Su.css
@@ -1,7 +1,3 @@
 .su {
   text-align: left;
 }
-
-/*.report {
-  padding-top: 15px
-}*/

--- a/src/GuanKiann/Su/Su.jsx
+++ b/src/GuanKiann/Su/Su.jsx
@@ -20,7 +20,7 @@ class Su extends React.Component {
     this.state = {
       按呢講好: props.suData.按呢講好,
       按呢無好: props.suData.按呢無好,
-      voted: cookie.load('vote_' + props.suId),
+      voted: cookie.load('vote_' + props.suId)
     };
   }
 
@@ -32,106 +32,102 @@ class Su extends React.Component {
 
     var 票 = {
       平臺項目編號: this.props.suId,
-      decision: evt,
+      decision: evt
     };
-    superagent.post(後端.投票())
-      .withCredentials()
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .set('X-CSRFToken', this.props.csrftoken)
-      .send(票)
-      .then(({ body }) => {if (body.success) cookie.save('vote_' + body.suId, evt, { path: '/' });})
-      .catch(res => {
-        console.log(res);
-      });
+    superagent.post(後端.投票()).withCredentials().set('Content-Type', 'application/x-www-form-urlencoded').set('X-CSRFToken', this.props.csrftoken).send(票).then(({body}) => {
+      if (body.success)
+        cookie.save('vote_' + body.suId, evt, {path: '/'});
+      }
+    ).catch(res => {
+      console.log(res);
+    });
     if (evt === '按呢講好')
       this.setState({
         按呢講好: this.props.suData.按呢講好 + 1,
-        voted: evt,
+        voted: evt
       });
     else if (evt === '按呢無好')
       this.setState({
         按呢無好: this.props.suData.按呢無好 + 1,
-        voted: evt,
+        voted: evt
       });
-  }
+    }
 
   render() {
-    let { suText, suIm, suId, 貢獻者, suData } = this.props;
-    if (貢獻者 == '匿名') 貢獻者 = '沒有人';
+    let {suText, suIm, suId, 貢獻者, suData} = this.props;
+    if (貢獻者 == '匿名')
+      貢獻者 = '沒有人';
     if (suData.結果 == -2) {
       return <div className='su item'></div>;
     }
 
-    let 按呢講的外語 = this.props.按呢講的外語列表.map((外語)=>(<TuiIngHuaGi key={外語.外語項目編號} 外語={外語}/>));
+    let 按呢講的外語 = this.props.按呢講的外語列表.map((外語) => (<TuiIngHuaGi key={外語.外語項目編號} 外語={外語}/>));
     return (
     <div className='su ui card'>
       <div className='content'>
-        <div className='left floated'>
-          <div className='ui header'>
-          {suText} <例句鈕仔 來開例句={this.props.來開例句.bind(this)}/>
-
-          </div>
+        <div className='ui header'>
+          {suText}
         </div>
         <div className='description'>
-          {suIm} <HuatIm 音標={suIm} />
-          <a title='這條沒聲音' onClick={
-            () => {
+          {suIm} <HuatIm 音標={suIm}/>
+          <a title='這條沒聲音' onClick={() => {
               let appVersion = navigator.appVersion;
               let d = new Date();
               let n = d.toISOString();
               console.log('這條沒聲音\n' + '時間：' + n + '\n' + 'appVersion: ' + appVersion);
-            }
-          }>
-            🙉
+            }}>🙉
           </a>
         </div>
         <div className='subtext'>
-          <LaiLik 貢獻者={貢獻者} />
+          <LaiLik 貢獻者={貢獻者}/>
           華語：{按呢講的外語}
         </div>
-      <div className='right floated'>
-        <div className='actions'>
-          <a className={
-            'item'
-            + (this.state.voted ? ' disabled' : '')}
-            onClick={this.投票.bind(this, '按呢講好')}>
-            <i className='icon check'></i>
-            按呢講好 {this.state.按呢講好 || suData.按呢講好}
-          </a>
-          <a className={
-            'item'
-            + (this.state.voted ? ' disabled' : '')}
-            onClick={this.投票.bind(this, '按呢無好')}>
-            <i className='icon close'></i>
-            按呢怪怪 {this.state.按呢無好 || suData.按呢無好}
-          </a>
-
+      </div>       
+        <div className='right floated'>
+          <div className='actions'>
+            <例句鈕仔 來開例句={this.props.來開例句.bind(this)}/>
+          <div title='按呢講好' tabindex="0" className={'ui labeled button item' + (
+                this.state.voted
+                ? ' disabled'
+                : '')} onClick={this.投票.bind(this, '按呢講好')}>
+                  <div className="ui icon button">
+                    <i className="icon heart"></i>
+                  </div>
+                  <div className="ui basic label">
+                    {this.state.按呢講好 || suData.按呢講好}
+                  </div>
+            </div>
+            <div title='按呢怪怪' className={'ui labeled button item' + (
+                this.state.voted
+                ? ' disabled'
+                : '')} onClick={this.投票.bind(this, '按呢無好')}>
+                <div className="ui icon button">
+                  <i className="icon close"></i>
+                </div>
+                  <div className="ui basic label">
+                    {this.state.按呢無好 || suData.按呢無好}
+                </div>
+            </div>
+          </div>
         </div>
-        </div>
-      </div>
-    </div>
-    );
+    </div>);
   }
 }
 
 export default Transmit.createContainer(Su, {
   initialVariables: {},
   fragments: {
-    suData({ 詞 }) {
-      return superagent.get(後端.平臺項目內容(詞.新詞文本項目編號))
-        .then((res) => Object.assign({
-            '結果': 0,
-          }, res.body))
-        .catch((err) => console.log(err));
+    suData({詞}) {
+      return superagent.get(後端.平臺項目內容(詞.新詞文本項目編號)).then((res) => Object.assign({
+        '結果': 0
+      }, res.body)).catch((err) => console.log(err));
     },
 
-    按呢講的外語列表({ 詞 }) {
-      return superagent.get(後端.揣按呢講列表(詞.文本資料, 詞.音標資料))
-        .then(({ body }) => body.列表)
-        .catch((err) => console.log(err));
-    },
+    按呢講的外語列表({詞}) {
+      return superagent.get(後端.揣按呢講列表(詞.文本資料, 詞.音標資料)).then(({body}) => body.列表).catch((err) => console.log(err));
+    }
   },
   shouldContainerUpdate(nextVariables) {
     return this.variables.詞 != nextVariables.詞;
-  },
+  }
 });

--- a/src/GuanKiann/Su/Su.jsx
+++ b/src/GuanKiann/Su/Su.jsx
@@ -67,39 +67,14 @@ class Su extends React.Component {
     <div className='su ui card'>
       <div className='content'>
         <div className='left floated'>
-          <h2 className='ui header'>
-          {suText}
-          </h2>
+          <div className='ui header'>
+          {suText} <例句鈕仔 來開例句={this.props.來開例句.bind(this)}/>
+
+          </div>
         </div>
-        <HuatIm 音標={suIm} />
-        <例句鈕仔 來開例句={this.props.來開例句.bind(this)} />
         <div className='description'>
-          {suIm}
-          <LaiLik 貢獻者={貢獻者} />
-          華語：
-          <span className='ui horizontal list large'>
-            {按呢講的外語}
-          </span>
-        </div>
-        <br/>
-        <div className='ui compact menu large'>
-          <a className={
-            'item'
-            + (this.state.voted ? ' disabled' : '')}
-            onClick={this.投票.bind(this, '按呢講好')}>
-            <i className='icon heart'></i>
-            按呢講好 <span className='floating ui label yellow'>{this.state.按呢講好 || suData.按呢講好}</span>
-          </a>
-          <a className={
-            'item'
-            + (this.state.voted ? ' disabled' : '')}
-            onClick={this.投票.bind(this, '按呢無好')}>
-            <i className='icon help circle'></i>
-            按呢怪怪 <span className='floating ui label orange'>{this.state.按呢無好 || suData.按呢無好}</span>
-          </a>
-        </div>
-        <div className='report'>
-          <a onClick={
+          {suIm} <HuatIm 音標={suIm} />
+          <a title='這條沒聲音' onClick={
             () => {
               let appVersion = navigator.appVersion;
               let d = new Date();
@@ -107,8 +82,31 @@ class Su extends React.Component {
               console.log('這條沒聲音\n' + '時間：' + n + '\n' + 'appVersion: ' + appVersion);
             }
           }>
-            🙋 這條沒聲音
+            🙉
           </a>
+        </div>
+        <div className='subtext'>
+          <LaiLik 貢獻者={貢獻者} />
+          華語：{按呢講的外語}
+        </div>
+      <div className='right floated'>
+        <div className='actions'>
+          <a className={
+            'item'
+            + (this.state.voted ? ' disabled' : '')}
+            onClick={this.投票.bind(this, '按呢講好')}>
+            <i className='icon check'></i>
+            按呢講好 {this.state.按呢講好 || suData.按呢講好}
+          </a>
+          <a className={
+            'item'
+            + (this.state.voted ? ' disabled' : '')}
+            onClick={this.投票.bind(this, '按呢無好')}>
+            <i className='icon close'></i>
+            按呢怪怪 {this.state.按呢無好 || suData.按呢無好}
+          </a>
+
+        </div>
         </div>
       </div>
     </div>

--- a/src/GuanKiann/Su/Su.jsx
+++ b/src/GuanKiann/Su/Su.jsx
@@ -69,13 +69,13 @@ class Su extends React.Component {
           {suText}
         </div>
         <div className='description'>
-          {suIm} <HuatIm 音標={suIm}/>
+          {suIm}
           <a title='這條沒聲音' onClick={() => {
               let appVersion = navigator.appVersion;
               let d = new Date();
               let n = d.toISOString();
               console.log('這條沒聲音\n' + '時間：' + n + '\n' + 'appVersion: ' + appVersion);
-            }}>🙉
+            }}> 🙉
           </a>
         </div>
         <div className='subtext'>
@@ -85,6 +85,7 @@ class Su extends React.Component {
       </div>       
         <div className='right floated'>
           <div className='actions'>
+             <HuatIm 音標={suIm}/>
             <例句鈕仔 來開例句={this.props.來開例句.bind(this)}/>
           <div title='按呢講好' tabindex="0" className={'ui labeled button item' + (
                 this.state.voted

--- a/src/GuanKiann/Su/SuTsitPuann.jsx
+++ b/src/GuanKiann/Su/SuTsitPuann.jsx
@@ -17,9 +17,9 @@ export default class SuTsitPuann extends React.Component {
     <div className='su ui card'>
       <div className='content'>
         <div className='left floated'>
-          <h2 className='ui header'>
+          <div className='ui header'>
           {文本資料}
-          </h2>
+          </div>
         </div>
         <HuatIm 音標={音標資料} />
         <例句鈕仔 來開例句={this.props.來開例句.bind(this)} />
@@ -32,4 +32,3 @@ export default class SuTsitPuann extends React.Component {
     );
   }
 }
-

--- a/src/GuanKiann/ToLam/ToLam.css
+++ b/src/GuanKiann/ToLam/ToLam.css
@@ -25,7 +25,7 @@
 }
 
 /* Mobile */
-@media only screen and (max-width: 767px) {
+@media only screen and (max-width: 727px) {
   .app.bar > .title{
     width: 100%;
     text-align: center;

--- a/src/GuanKiann/Tshue/Tshue.css
+++ b/src/GuanKiann/Tshue/Tshue.css
@@ -6,7 +6,7 @@
 
 
 /* Mobile */
-@media only screen and (max-width: 767px) {
+@media only screen and (max-width: 727px) {
   .ui.fluid.action.input.tshue {
     margin-left: 0 !important;
     margin-right: 0 !important;

--- a/src/GuanKiann/例句/例句表.jsx
+++ b/src/GuanKiann/例句/例句表.jsx
@@ -56,7 +56,7 @@ class 例句表 extends React.Component {
           onRequestClose={this.props.關例句.bind(this)}
           style={customStyles}
           >
-          <h2 ref="subtitle">{漢字} {台羅}<HuatIm 音標={台羅}/></h2>
+          <span className='ui header' ref="subtitle">{漢字} {台羅}</span>  <HuatIm 音標={台羅}/>
 
           <div>
             <span className="分享">

--- a/src/GuanKiann/例句/例句鈕仔.jsx
+++ b/src/GuanKiann/例句/例句鈕仔.jsx
@@ -16,12 +16,10 @@ export default class 例句鈕仔 extends React.Component {
     }
 
     return (
-      <span className='ui icon button'>
-        <div
+      <span className='ui icon button'
           onClick={來開例句.bind(this)}
           title='例句'>
-          <i className='icon external'></i>
-        </div>
+        <i className='icon external'></i>
       </span>
 
     );

--- a/src/GuanKiann/例句/例句鈕仔.jsx
+++ b/src/GuanKiann/例句/例句鈕仔.jsx
@@ -16,13 +16,14 @@ export default class 例句鈕仔 extends React.Component {
     }
 
     return (
-      <span className=''>
-        <a
+      <span className='ui icon button'>
+        <div
           onClick={來開例句.bind(this)}
           title='例句'>
-          <i className='icon list'></i>
-        </a>
+          <i className='icon external'></i>
+        </div>
       </span>
+
     );
   }
 }

--- a/src/GuanKiann/例句/例句鈕仔.jsx
+++ b/src/GuanKiann/例句/例句鈕仔.jsx
@@ -17,13 +17,12 @@ export default class 例句鈕仔 extends React.Component {
 
     return (
       <span className=''>
-        <button
+        <a
           onClick={來開例句.bind(this)}
-          className='ui compact icon button'>
-          <i className='icon content'></i>
-        </button>
+          title='例句'>
+          <i className='icon list'></i>
+        </a>
       </span>
     );
   }
 }
-

--- a/src/GuanKiann/其他建議/一个建議.jsx
+++ b/src/GuanKiann/其他建議/一个建議.jsx
@@ -18,9 +18,10 @@ class 一个建議 extends React.Component {
     return (
     <div className='ui su card'>
       <div className='content'>
-        <div className='left floated'>
-          <div className='ui header'>
-          {文本資料} <例句鈕仔 來開例句={this.props.來開例句.bind(this)} />
+        <div className='ui header'>
+          {文本資料}
+          <div className='right floated'>
+            <例句鈕仔 來開例句={this.props.來開例句.bind(this)} />
           </div>
         </div>
         <div className='description'>

--- a/src/GuanKiann/其他建議/一个建議.jsx
+++ b/src/GuanKiann/其他建議/一个建議.jsx
@@ -20,12 +20,9 @@ class 一个建議 extends React.Component {
       <div className='content'>
         <div className='ui header'>
           {文本資料}
-          <div className='right floated'>
-            <例句鈕仔 來開例句={this.props.來開例句.bind(this)} />
-          </div>
         </div>
         <div className='description'>
-          {音標資料} <HuatIm 音標={音標資料} />
+          {音標資料}
         </div>
         <div className='subtext'>
           <div>
@@ -34,6 +31,11 @@ class 一个建議 extends React.Component {
             {按呢講的外語}
           </div>
           </div>
+        </div>
+      </div>
+      <div className='right floated'>
+        <div className='actions'>
+           <HuatIm 音標={音標資料} /> <例句鈕仔 來開例句={this.props.來開例句.bind(this)}/>
         </div>
       </div>
     </div>

--- a/src/GuanKiann/其他建議/一个建議.jsx
+++ b/src/GuanKiann/其他建議/一个建議.jsx
@@ -19,18 +19,20 @@ class 一个建議 extends React.Component {
     <div className='ui su card'>
       <div className='content'>
         <div className='left floated'>
-          <h2 className='ui header'>
-          {文本資料}
-          </h2>
+          <div className='ui header'>
+          {文本資料} <例句鈕仔 來開例句={this.props.來開例句.bind(this)} />
+          </div>
         </div>
-        <HuatIm 音標={音標資料} />
-        <例句鈕仔 來開例句={this.props.來開例句.bind(this)} />
         <div className='description'>
-          {音標資料}<br/>
+          {音標資料} <HuatIm 音標={音標資料} />
+        </div>
+        <div className='subtext'>
+          <div>
           華語：
-          <span className='ui horizontal list large'>
+          <div className='ui horizontal list'>
             {按呢講的外語}
-          </span>
+          </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/GuanKiann/其他建議/一个建議一半.jsx
+++ b/src/GuanKiann/其他建議/一个建議一半.jsx
@@ -19,9 +19,9 @@ class 一个建議 extends React.Component {
     <div className='ui su card'>
       <div className='content'>
         <div className='left floated'>
-          <h2 className='ui header'>
+          <div className='ui header'>
           {文本資料}
-          </h2>
+					</div>
         </div>
         <HuatIm 音標={音標資料} />
         <例句鈕仔 來開例句={this.props.來開例句.bind(this)} />

--- a/src/Iah/Iong/Iong.css
+++ b/src/Iah/Iong/Iong.css
@@ -1,10 +1,10 @@
 div.iong {
-	margin: 0 auto;
-	padding-top:1em;
+  margin: 0 auto;
+  padding-top:1em;
 }
 
 /* Mobile */
-@media only screen and (max-width: 767px) {
+@media only screen and (max-width: 727px) {
   .iong .ui.cards {
     justify-content: center;
   }

--- a/src/Iah/Kong/其他建議.css
+++ b/src/Iah/Kong/其他建議.css
@@ -1,5 +1,5 @@
 /* Mobile */
-@media only screen and (max-width: 767px) {
+@media only screen and (max-width: 727px) {
   .kianGi .ui.cards {
     justify-content: center;
   }


### PR DESCRIPTION
[11/22 參考丞宏建議，把功能以labeled button集中在右下，使用彈出的icon以表例句之彈出，以平衡右邊可能的空白，標題加大，臺羅與之以黃金比例，為 10:16。 解conflict請選此branch ](https://github.com/g0v/itaigi/pull/446#issuecomment-346217998)
11/21 參考了一下 [cards](https://material.io/guidelines/components/cards.html#cards-content-blocks)官方建議，降低連結銳利度，群組聲音相關功能 (發音與回報沒聲音)，群組回饋功能(這個好，這個怪)，設定CSS，依標題，小標，主文。敬請指導