### PR TITLE
voice的domain name先直接用阮這爿的

### DIFF
--- a/src/GuanKiann/HuatIm/HapSing.jsx
+++ b/src/GuanKiann/HuatIm/HapSing.jsx
@@ -32,7 +32,7 @@ export default class HapSing extends React.Component {
         <audio ref="音樂">
           <source type='audio/x-wav'
             src={
-              encodeURI('https://voice.itaigi.tw/文本直接合成?查詢腔口=閩南語&查詢語句=') +
+              encodeURI('https://xn--lhrz38b.xn--v0qr21b.xn--kpry57d/文本直接合成?查詢腔口=閩南語&查詢語句=') +
               encodeURIComponent(標漢字音標)
             }
            />


### PR DESCRIPTION
因為voice.itaigi.tw  certification RENEW一直出問題，先改qwoln